### PR TITLE
Save and copy Ontology IRI of  parsed ontologies 

### DIFF
--- a/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
+++ b/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
@@ -143,6 +143,21 @@ public class OntologyParser {
 	}
 
 	/**
+	 * Get the source ontology IRI and add it to the target ontology
+	 *
+	 * @param sourceOnt
+	 */
+	private void addOntologyIRI(OWLOntology sourceOnt) {
+		Optional<IRI> ontologyIRI = sourceOnt.getOntologyID().getOntologyIRI();
+		Optional<IRI> versionIRI =  sourceOnt.getOntologyID().getVersionIRI();
+		if (ontologyIRI.isPresent()) {
+			OWLOntologyID newOntologyID = new OWLOntologyID(ontologyIRI, versionIRI);
+			SetOntologyID setOntologyID = new SetOntologyID(targetOwlOntology, newOntologyID);
+			this.targetOwlManager.applyChange(setOntologyID);
+		}
+	}
+
+	/**
 	 * Copies ontology-level annotation axioms from the source ontology to the target ontology.
 	 * <p>
 	 * Checks for the owl#versionInfo property. If found, adds a BioPortal-specific "versionSubject"
@@ -177,13 +192,14 @@ public class OntologyParser {
 		}
 	}
 
-	private boolean buildOWLOntology(boolean isOBO) {
+	private boolean buildOWLOntology(OWLOntology masterOntology, boolean isOBO) {
 
 		Set<OWLAxiom> allAxioms = new HashSet<OWLAxiom>();
 
 		OWLDataFactory fact = sourceOwlManager.getOWLDataFactory();
 		try {
 			targetOwlOntology = targetOwlManager.createOntology();
+			addOntologyIRI(masterOntology);
 		} catch (OWLOntologyCreationException e) {
 			log.error(e.getMessage());
 			parserLog.addError(ParserError.OWL_CREATE_ONTOLOGY_EXCEPTION, "Error buildOWLOntology" + e.getMessage());
@@ -532,7 +548,7 @@ public class OntologyParser {
 
 		boolean isOBO = isOBO(ontology);
 
-		if (!buildOWLOntology(isOBO)) return false;
+		if (!buildOWLOntology(ontology, isOBO)) return false;
 
 		if (!serializeOntology()) return false;
 

--- a/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
+++ b/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
@@ -54,6 +54,12 @@ public class OntologyParser {
 		this.targetOwlManager = OWLManager.createOWLOntologyManager();
 	}
 
+
+	public OWLOntology getTargetOwlOntology() {
+		return targetOwlOntology;
+	}
+
+
 	public List<OntologyBean> getLocalOntologies() {
 		return ontologies;
 	}

--- a/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
+++ b/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
@@ -29,6 +29,7 @@ import java.util.*;
 
 public class OntologyParser {
 	private final static Logger log = LoggerFactory.getLogger(OntologyParser.class.getName());
+	public static final String VERSION_SUBJECT = "http://bioportal.bioontology.org/ontologies/versionSubject";
 
 	protected ParserInvocation parserInvocation = null;
 	private ParserLog parserLog = null;
@@ -162,7 +163,7 @@ public class OntologyParser {
 			targetOwlManager.addAxiom(targetOwlOntology, annotationAssertionAxiom);
 
 			if (isFile && (annotationProperty.toString().contains("versionInfo"))) {
-				IRI versionSubjectIRI = IRI.create("http://bioportal.bioontology.org/ontologies/versionSubject");
+				IRI versionSubjectIRI = IRI.create(VERSION_SUBJECT);
 				OWLAnnotationProperty versionAnnotationProperty = factory.getOWLAnnotationProperty(OWLRDFVocabulary.OWL_VERSION_INFO.getIRI());
 				OWLAnnotationAssertionAxiom versionAnnotationAssertionAxiom = factory.getOWLAnnotationAssertionAxiom(versionAnnotationProperty, versionSubjectIRI, annotationValue);
 				targetOwlManager.addAxiom(targetOwlOntology, versionAnnotationAssertionAxiom);
@@ -213,7 +214,7 @@ public class OntologyParser {
 			if (oboVersion != null) {
 				log.info("Adding version: {}", oboVersion);
 				OWLAnnotationProperty prop = fact.getOWLAnnotationProperty(IRI.create(OWLRDFVocabulary.OWL_VERSION_INFO.toString()));
-				IRI versionSubjectIRI = IRI.create("http://bioportal.bioontology.org/ontologies/versionSubject");
+				IRI versionSubjectIRI = IRI.create(VERSION_SUBJECT);
 				OWLAnnotationAssertionAxiom annVersion = fact.getOWLAnnotationAssertionAxiom(prop, versionSubjectIRI, fact.getOWLLiteral(oboVersion));
 				targetOwlManager.addAxiom(targetOwlOntology, annVersion);
 			}

--- a/src/test/java/org/stanford/ncbo/owlapi/wrapper/OntologyParserTest.java
+++ b/src/test/java/org/stanford/ncbo/owlapi/wrapper/OntologyParserTest.java
@@ -3,6 +3,7 @@ package org.stanford.ncbo.owlapi.wrapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.semanticweb.owlapi.model.IRI;
 
 import java.io.File;
 
@@ -123,6 +124,25 @@ public class OntologyParserTest {
                 "./src/test/resources/repo/output/embedded_xml", "testXMLLiteral.owl", true);
         OntologyParser parser = new OntologyParser(pi);
         assertTrue(parser.parse());
+    }
+
+
+    @Test
+    public void parse_DetectsOntologyIRI_ReturnsTrue() throws Exception {
+        String outputRepositoryFolder = "./src/test/resources/repo/output/cno";
+        ParserInvocation pi = new ParserInvocation("./src/test/resources/repo/input/cno",
+                outputRepositoryFolder, "cnov0_5.owl", true);
+        assertTrue(pi.valid());
+
+        OntologyParser parser = new OntologyParser(pi);
+        assertTrue(parser.parse());
+        assertEquals(1, parser.getLocalOntologies().size());
+
+        IRI targetIRI = parser.getTargetOwlOntology().getOntologyID().getOntologyIRI().orNull();
+        IRI sourceIRI = parser.getParsedOntologies().stream().findFirst().get().getOntologyID().getOntologyIRI().orNull();
+        assertNotNull(targetIRI);
+        assertEquals(sourceIRI, targetIRI);
+
     }
 
     @After


### PR DESCRIPTION
## Issue

The issue is that when the owlapi_wrapper parse an ontology doesn't copy the original IRI and just creates anonymous ontology

You can test it using this
```java
String outputRepositoryFolder = "./src/test/resources/repo/output/cno";
ParserInvocation pi = new ParserInvocation("./src/test/resources/repo/input/cno",
outputRepositoryFolder, "cnov0_5.owl", true);
assertTrue(pi.valid());

OntologyParser parser = new OntologyParser(pi);
assertTrue(parser.parse());
assertEquals(1, parser.getLocalOntologies().size());

IRI targetIRI = parser.getTargetOwlOntology().getOntologyID().getOntologyIRI().orNull();
IRI sourceIRI = parser.getParsedOntologies().stream().findFirst().get().getOntologyID().getOntologyIRI().orNull();
assertNotNull(targetIRI);
assertEquals(sourceIRI, targetIRI);
```

#### In the original file, we have 
```xml
 <owl:Ontology rdf:about="http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl">
        <dc:date rdf:datatype="&xsd;string">13/03/2012</dc:date>
        <dc:subject rdf:datatype="&xsd;string">An ontology to describe the field of Computational Neurosciences</dc:subject>
        <dc:contributor rdf:datatype="&xsd;string">Birgit Kriener</dc:contributor>
```
#### The created file contains the following (does not more contain the rdf:about)
```xml
<owl:Ontology >
        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alan Ruttenberg</dc:contributor>
        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Andrew Spear</dc:contributor>
        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Birgit Kriener</dc:contributor>
        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erik De Schutter</dc:contributor>
        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fahim T. Imam</dc:contributor>
```

## Solution 
This PR, by just adding these lines 
```java
Optional<IRI> ontologyIRI = sourceOnt.getOntologyID().getOntologyIRI();
Optional<IRI> versionIRI =  sourceOnt.getOntologyID().getVersionIRI();
if (ontologyIRI.isPresent()) {
        OWLOntologyID newOntologyID = new OWLOntologyID(ontologyIRI, versionIRI);
	SetOntologyID setOntologyID = new SetOntologyID(targetOwlOntology, newOntologyID);
	this.targetOwlManager.applyChange(setOntologyID);
}
```

## Why do we need the ontology IRI
https://github.com/ncbo/ontologies_linked_data/issues/152