### PR TITLE
add GitHub release workflow and update pom.xml for external versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Publish Release to GitHub
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Extract version from tag
+        id: vars
+        run: |
+          TAG_NAME=${GITHUB_REF##*/}
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+(\.[0-9]+)*$ ]]; then
+            echo "Invalid tag format: $TAG_NAME"
+            exit 1
+          fi
+          VERSION=${TAG_NAME#v}
+          echo "tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build JAR
+        run: mvn -B clean package -DskipTests=true -Drevision=${{ steps.vars.outputs.version }}
+
+      - name: Upload JAR to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/owlapi-wrapper-${{ steps.vars.outputs.version }}.jar
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.stanford.ncbo.oapiwrapper</groupId>
   <artifactId>owlapi-wrapper</artifactId>
-  <version>1.4.3-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <name>owlapi_wrapper</name>
@@ -99,6 +99,7 @@
   </issueManagement>
 
   <properties>
+    <revision>1.4.3-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -217,11 +218,14 @@
         </executions>
       </plugin>
 
+      <!-- Commented out: we use Git tag–driven releases instead -->
+      <!--
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
       </plugin>
+      -->
 
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Introduces a new GitHub Actions workflow to publish JARs on release. Updates pom.xml to use externally injected versioning via the ${revision} property, replacing the Maven Release Plugin, which is now disabled.

addresses 
- https://github.com/ncbo/owlapi_wrapper/issues/26