### PR TITLE
Handle invalid QNames when generating prefixIRI metadata

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2012-2026, The Board of Trustees of Leland Stanford Junior University
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+   conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list
+   of conditions and the following disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY The Board of Trustees of Leland Stanford Junior University
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL The Board of Trustees of Leland Stanford Junior University OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@
 
 A command line utility that wraps the Java [OWL API](https://github.com/owlcs/owlapi) for parsing RDFS, OWL, and OBO ontologies. 
 
+## Contributors
+<a href="https://github.com/ncbo/owlapi_wrapper/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=ncbo/owlapi_wrapper" />
+</a>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
 # owlapi_wrapper
 
+[![Java Unit Tests](https://github.com/ncbo/owlapi_wrapper/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/ncbo/owlapi_wrapper/actions/workflows/unit-tests.yml)
 [![codecov](https://codecov.io/gh/ncbo/owlapi_wrapper/graph/badge.svg?token=HEt3yP8T0i)](https://codecov.io/gh/ncbo/owlapi_wrapper)
+[![GitHub Release](https://img.shields.io/github/v/release/ncbo/owlapi_wrapper)](https://github.com/ncbo/owlapi_wrapper/releases)
+[![License: BSD 2-Clause](https://img.shields.io/badge/License-BSD%202--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 
-A command line utility that wraps the Java [OWL API](https://github.com/owlcs/owlapi) for parsing RDFS, OWL, and OBO ontologies. 
+`owlapi_wrapper` is a small Java command-line tool built around the [OWL API](https://github.com/owlcs/owlapi). It parses OWL, RDF(S), SKOS, 
+and OBO ontologies and writes a normalized RDF/XML export plus a small metrics report.
+
+The project is used in the [BioPortal](https://bioportal.bioontology.org/) ecosystem to load ontologies and add a few BioPortal-oriented annotations 
+during serialization.
+
+## Features
+
+- Parses a master ontology file from a local repository of ontology files
+- Writes a serialized RDF/XML output file named `owlapi.xrdf`.
+- Writes a `metrics.csv` file with class, individual, property, and max-depth counts.
+- Adds some normalization used by BioPortal, e.g., SKOS notation or prefix annotations for classes 
+
+## License
+
+The 2-Clause BSD License. See [LICENSE.md](LICENSE.md) for more information.
 
 ## Contributors
+
 <a href="https://github.com/ncbo/owlapi_wrapper/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ncbo/owlapi_wrapper" />
 </a>

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
       <version>1.10.0</version>
     </dependency>
 
-    <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   </organization>
   <licenses>
     <license>
-      <name>BSD 2-clause</name>
+      <name>BSD-2-Clause</name>
       <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>manual</distribution>
     </license>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
   </issueManagement>
 
   <properties>
-    <revision>1.4.3-SNAPSHOT</revision>
+    <revision>1.5.1-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,13 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.4.14</version>
+      <version>1.5.32</version>
     </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.14</version>
+      <version>1.5.32</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
+++ b/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
@@ -376,6 +376,18 @@ public class OntologyParser {
 		}
 	}
 
+	/**
+	 * Generates identifier annotations for named classes in OWL ontologies.
+	 * <p>
+	 * Existing {@code skos:notation} annotations are preserved. If absent, {@code oboInOwl:id}
+	 * is copied into {@code skos:notation}. Otherwise, BioPortal {@code prefixIRI} metadata is
+	 * generated from the class IRI, using a prefixed form when available and the IRI short form
+	 * as a fallback.
+	 *
+	 * @param allAxioms the set of axioms being accumulated for the target ontology
+	 * @param fact the OWL data factory used to create annotation axioms
+	 * @param sourceOnt the source ontology whose class identifiers are being processed
+	 */
 	private void generateSKOSInOwl(Set<OWLAxiom> allAxioms, OWLDataFactory fact, OWLOntology sourceOnt) {
 		OWLDocumentFormat docFormat = this.sourceOwlManager.getOntologyFormat(sourceOnt);
 		PrefixDocumentFormat prefixFormat = docFormat.asPrefixOWLOntologyFormat();

--- a/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
+++ b/src/main/java/org/stanford/ncbo/owlapi/wrapper/OntologyParser.java
@@ -424,11 +424,12 @@ public class OntologyParser {
 						b.replace(ind, ind + 1, ":");
 						prefixIRI = b.toString();
 					}
-
-					OWLAnnotationProperty prop = fact.getOWLAnnotationProperty(IRI.create("http://data.bioontology.org/metadata/prefixIRI"));
-					OWLAxiom annAsse = fact.getOWLAnnotationAssertionAxiom(prop, cls.getIRI(), fact.getOWLLiteral(prefixIRI));
-					allAxioms.add(annAsse);
+				} else {
+					prefixIRI = cls.getIRI().getShortForm();
 				}
+				OWLAnnotationProperty prop = fact.getOWLAnnotationProperty(IRI.create("http://data.bioontology.org/metadata/prefixIRI"));
+				OWLAxiom annAsse = fact.getOWLAnnotationAssertionAxiom(prop, cls.getIRI(), fact.getOWLLiteral(prefixIRI));
+				allAxioms.add(annAsse);
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes `prefixIRI` generation for OWL classes whose IRIs don't resolve to a valid QName.

Refs #32.

### Changes
* Update `generateSKOSInOwl` to fall back to `IRI.getShortForm()` when no valid prefixed QName is available
* Add Javadoc for `generateSKOSInOwl`
* Correct the project revision to `1.5.1-SNAPSHOT`
* Remove a duplicate `jaxb-api` dependency
* Bump Logback to 1.5.32
* Add `LICENSE.md` with canonical BSD-2-Clause text
* Augment `README.md` with badges and brief project metadata
